### PR TITLE
[RFC] Virtio mmio i2c

### DIFF
--- a/arch/arm/boot/dts/st/stm32mp157c-ed1.dts
+++ b/arch/arm/boot/dts/st/stm32mp157c-ed1.dts
@@ -58,6 +58,18 @@
 			no-map;
 		};
 
+		mmio0: mmio0@10050000 {
+			compatible = "shared-dma-pool";
+			reg = <0x10050000 0x200>;
+			no-map;
+		};
+
+		virtio0mem: virtio0mem@10050200 {
+			compatible = "shared-dma-pool";
+			reg = <0x10050200 0x7E00>;
+			no-map;
+		};
+
 		mcuram: mcuram@30000000 {
 			compatible = "shared-dma-pool";
 			reg = <0x30000000 0x40000>;
@@ -315,12 +327,25 @@
 
 &m4_rproc {
 	memory-region = <&retram>, <&mcuram>, <&mcuram2>, <&vdev0vring0>,
-			<&vdev0vring1>, <&vdev0buffer>;
+			<&vdev0vring1>, <&vdev0buffer>, <&mmio0>;
 	mboxes = <&ipcc 0>, <&ipcc 1>, <&ipcc 2>, <&ipcc 3>;
 	mbox-names = "vq0", "vq1", "shutdown", "detach";
 	interrupt-parent = <&exti>;
 	interrupts = <68 1>;
 	status = "okay";
+
+	ranges;
+
+	#address-cells = <1>;
+	#size-cells = <1>;
+	mmio@10050000 {
+		compatible = "virtio,mmio-remoteproc";
+		reg = <0x10050000 0x100>;
+		interrupts-extended = <&ipcc 4>;
+		memory-region = <&virtio0mem>;
+		mboxes = <&ipcc 5>;
+		mbox-names = "sync_mb";
+	};
 };
 
 &pwr_regulators {

--- a/arch/arm/boot/dts/st/stm32mp157c-ed1.dts
+++ b/arch/arm/boot/dts/st/stm32mp157c-ed1.dts
@@ -304,6 +304,8 @@
 
 &ipcc {
 	status = "okay";
+	#interrupt-cells = <1>;
+	interrupt-controller;
 };
 
 &iwdg2 {

--- a/arch/arm/boot/dts/st/stm32mp15xx-dkx.dtsi
+++ b/arch/arm/boot/dts/st/stm32mp15xx-dkx.dtsi
@@ -454,6 +454,8 @@
 
 &ipcc {
 	status = "okay";
+	#interrupt-cells = <1>;
+	interrupt-controller;
 };
 
 &iwdg2 {

--- a/arch/arm/boot/dts/st/stm32mp15xx-dkx.dtsi
+++ b/arch/arm/boot/dts/st/stm32mp15xx-dkx.dtsi
@@ -48,6 +48,18 @@
 			no-map;
 		};
 
+		mmio0: mmio0@10050000 {
+			compatible = "shared-dma-pool";
+			reg = <0x10050000 0x200>;
+			no-map;
+		};
+
+		virtio0mem: virtio0mem@10050200 {
+			compatible = "shared-dma-pool";
+			reg = <0x10050200 0x7E00>;
+			no-map;
+		};
+
 		mcuram: mcuram@30000000 {
 			compatible = "shared-dma-pool";
 			reg = <0x30000000 0x40000>;
@@ -478,12 +490,25 @@
 
 &m4_rproc {
 	memory-region = <&retram>, <&mcuram>, <&mcuram2>, <&vdev0vring0>,
-			<&vdev0vring1>, <&vdev0buffer>;
+			<&vdev0vring1>, <&vdev0buffer>, <&mmio0>;
 	mboxes = <&ipcc 0>, <&ipcc 1>, <&ipcc 2>, <&ipcc 3>;
 	mbox-names = "vq0", "vq1", "shutdown", "detach";
 	interrupt-parent = <&exti>;
 	interrupts = <68 1>;
 	status = "okay";
+
+	ranges;
+
+	#address-cells = <1>;
+	#size-cells = <1>;
+	mmio@10050000 {
+		compatible = "virtio,mmio-remoteproc";
+		reg = <0x10050000 0x100>;
+		interrupts-extended = <&ipcc 4>;
+		memory-region = <&virtio0mem>;
+		mboxes = <&ipcc 5>;
+		mbox-names = "sync_mb";
+	};
 };
 
 &pwr_regulators {

--- a/include/linux/dma-direct.h
+++ b/include/linux/dma-direct.h
@@ -104,7 +104,8 @@ static inline bool dma_capable(struct device *dev, dma_addr_t addr, size_t size,
 	if (addr == DMA_MAPPING_ERROR)
 		return false;
 	if (is_ram && !IS_ENABLED(CONFIG_ARCH_DMA_ADDR_T_64BIT) &&
-	    min(addr, end) < phys_to_dma(dev, PFN_PHYS(min_low_pfn)))
+		(phys_addr_t)-1 != phys_to_dma(dev, PFN_PHYS(min_low_pfn)) &&
+		min(addr, end) < phys_to_dma(dev, PFN_PHYS(min_low_pfn)))
 		return false;
 
 	return end <= min_not_zero(*dev->dma_mask, dev->bus_dma_limit);


### PR DESCRIPTION
This PR proposes an implementation of the virtio-mmio and virti-i2c for inter-processor communication.

The objective of this PR is only to share a first implementation and should not be merged in this state.

- Update of the virtio -mmio to manage IPC signaling and device memory address ( with new compatibility)
- Add posibility to populate sub-node in the remoteproc framework

This PR is compatible with the Zephyr example : https://github.com/OpenAMP/openamp-system-reference/pull/20